### PR TITLE
Fixed TypeError in Python 3.2.1

### DIFF
--- a/pycksum/__init__.py
+++ b/pycksum/__init__.py
@@ -87,7 +87,7 @@ class Cksum:
     def add(self, obj):
         if hasattr(obj, '__iter__'):
             for b in iter(obj):
-                self._add(b)
+                self._add(b.encode('utf-8'))
         else:
             self._add(obj)
 


### PR DESCRIPTION
The function _memcksum resulted in a TypeError. Due to the strict type handling of python3 the passed over string in the add-method needed to be encoded to a single byte.
